### PR TITLE
Add missing tags file

### DIFF
--- a/doc/tags
+++ b/doc/tags
@@ -1,0 +1,9 @@
+DiagonContents	diagon.txt	/*DiagonContents*
+DiagonCredits	diagon.txt	/*DiagonCredits*
+DiagonLicense	diagon.txt	/*DiagonLicense*
+DiagonMappings	diagon.txt	/*DiagonMappings*
+DiagonOptions	diagon.txt	/*DiagonOptions*
+DiagonPrerequisites	diagon.txt	/*DiagonPrerequisites*
+DiagonUsage	diagon.txt	/*DiagonUsage*
+g:diagon_use_echo	diagon.txt	/*g:diagon_use_echo*
+vim-diagon.txt	diagon.txt	/*vim-diagon.txt*


### PR DESCRIPTION
With the current version, after installing this plugin as a submodule, a tag file is automatically generated when a file is opened in Vim.

However, it creates an annoying error when it keeps requiring to stage that tags file.

And since it is a submodule, I cannot push that tags file to GitHub.

So I generate a tags file and add it to the current plugin so that no new tags file is generated which solves the problem.
